### PR TITLE
Add certificate provider which reloads certs in case of errors

### DIFF
--- a/SigningServer.Client/Program.cs
+++ b/SigningServer.Client/Program.cs
@@ -346,6 +346,7 @@ internal class Program
             }
             else
             {
+                arg = arg.Trim('"');
                 if (File.Exists(arg) || Directory.Exists(arg))
                 {
                     configuration.Sources.Add(arg);

--- a/SigningServer.Server/ICertificateProvider.cs
+++ b/SigningServer.Server/ICertificateProvider.cs
@@ -1,0 +1,30 @@
+﻿using SigningServer.Server.Configuration;
+
+namespace SigningServer.Server;
+
+/// <summary>
+/// Represents a provider for certificates to use during signing.
+/// </summary>
+public interface ICertificateProvider
+{
+    /// <summary>
+    /// Obtains a new certificate for usage during signing. 
+    /// </summary>
+    /// <param name="username">The username to select the certificate</param>
+    /// <param name="password">The password to select the certificate</param>
+    /// <returns>A certificate configuration to use for signing</returns>
+    CertificateConfiguration Get(string username, string password);
+    
+    /// <summary>
+    /// Returns a certificate for usage by another party. 
+    /// </summary>
+    /// <param name="username">The username this certificate belongs to.</param>
+    /// <param name="certificateConfiguration">The certificate configuration to return</param>
+    void Return(string username, CertificateConfiguration certificateConfiguration);
+    
+    /// <summary>
+    /// Destroys the given certificate because it appears to not be usable anymore. 
+    /// </summary>
+    /// <param name="certificateConfiguration">The certificate to destroy.</param>
+    void Destroy(CertificateConfiguration certificateConfiguration);
+}

--- a/SigningServer.Server/NonPooledCertificateProvider.cs
+++ b/SigningServer.Server/NonPooledCertificateProvider.cs
@@ -1,0 +1,32 @@
+﻿using System.Linq;
+using SigningServer.Server.Configuration;
+
+namespace SigningServer.Server;
+
+public class NonPooledCertificateProvider : ICertificateProvider
+{
+    private readonly SigningServerConfiguration _configuration;
+    public NonPooledCertificateProvider(SigningServerConfiguration configuration)
+    {
+        _configuration = configuration;
+    }
+
+    public CertificateConfiguration Get(string username, string password)
+    {
+        if (string.IsNullOrWhiteSpace(username))
+        {
+            return _configuration.Certificates.FirstOrDefault(c => c.IsAnonymous);
+        }
+
+        return _configuration.Certificates.FirstOrDefault(
+            c => c.IsAuthorized(username, password));
+    }
+
+    public void Return(string username, CertificateConfiguration certificateConfiguration)
+    {
+    }
+    
+    public void Destroy(CertificateConfiguration certificateConfiguration)
+    {
+    }
+}

--- a/SigningServer.Server/PooledCertificateProvider.cs
+++ b/SigningServer.Server/PooledCertificateProvider.cs
@@ -1,0 +1,142 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.ObjectPool;
+using SigningServer.Server.Configuration;
+using SigningServer.Server.Util;
+
+namespace SigningServer.Server;
+
+public class PooledCertificateProvider : ICertificateProvider
+{
+    private readonly SigningServerConfiguration _configuration;
+    private readonly ObjectPoolProvider _objectPoolProvider;
+    private readonly ILogger<PooledCertificateProvider> _logger;
+    private readonly ILogger<CertificateConfiguration> _certConfigLogger;
+    private readonly HardwareCertificateUnlocker _hardwareCertificateUnlocker;
+
+    private readonly ConcurrentDictionary<string /*username*/, ObjectPool<CertificateConfiguration>>
+        _certificatePools = new();
+
+    public PooledCertificateProvider(
+        SigningServerConfiguration configuration,
+        ObjectPoolProvider objectPoolProvider,
+        ILogger<PooledCertificateProvider> logger,
+        ILogger<CertificateConfiguration> certConfigLogger,
+        HardwareCertificateUnlocker hardwareCertificateUnlocker)
+    {
+        _configuration = configuration;
+        _objectPoolProvider = objectPoolProvider;
+        _logger = logger;
+        _certConfigLogger = certConfigLogger;
+        _hardwareCertificateUnlocker = hardwareCertificateUnlocker;
+    }
+
+    private class CertificateCloningObjectPolicy : PooledObjectPolicy<CertificateConfiguration>
+    {
+        private readonly ILogger _logger;
+        private readonly CertificateConfiguration _baseConfiguration;
+        private readonly ILogger<CertificateConfiguration> _certConfigLogger;
+        private readonly HardwareCertificateUnlocker _hardwareCertificateUnlocker;
+
+        public CertificateCloningObjectPolicy(
+            ILogger logger,
+            CertificateConfiguration baseConfiguration,
+            ILogger<CertificateConfiguration> certConfigLogger,
+            HardwareCertificateUnlocker hardwareCertificateUnlocker)
+        {
+            _logger = logger;
+            _baseConfiguration = baseConfiguration;
+            _certConfigLogger = certConfigLogger;
+            _hardwareCertificateUnlocker = hardwareCertificateUnlocker;
+        }
+
+        public override CertificateConfiguration Create()
+        {
+            _logger.LogInformation($"Creating a new certificate instance for signing: {_baseConfiguration}");
+            try
+            {
+                return _baseConfiguration.CloneForSigning(_certConfigLogger, _hardwareCertificateUnlocker);
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, $"Failed to create a new certificate instance for signing: {_baseConfiguration}");
+                throw;
+            }
+        }
+
+        public override bool Return(CertificateConfiguration obj)
+        {
+            return true;
+        }
+    }
+
+    public CertificateConfiguration Get(string username, string password)
+    {
+        CertificateConfiguration baseConfiguration;
+        if (string.IsNullOrWhiteSpace(username))
+        {
+            baseConfiguration = _configuration.Certificates.FirstOrDefault(c => c.IsAnonymous);
+            username = string.Empty;
+        }
+        else
+        {
+            baseConfiguration = _configuration.Certificates.FirstOrDefault(
+                c => c.IsAuthorized(username, password));
+        }
+
+        if (baseConfiguration == null)
+        {
+            return null;
+        }
+
+        var pool = _certificatePools.GetOrAdd(username,
+            _ => _objectPoolProvider.Create(new CertificateCloningObjectPolicy(_logger,
+                baseConfiguration, _certConfigLogger,
+                _hardwareCertificateUnlocker))
+        );
+        return pool.Get();
+    }
+
+    public void Return(string username, CertificateConfiguration certificateConfiguration)
+    {
+        if (certificateConfiguration == null)
+        {
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(username))
+        {
+            username = string.Empty;
+        }
+
+        _certificatePools[username].Return(certificateConfiguration);
+    }
+
+    public void Destroy(CertificateConfiguration certificateConfiguration)
+    {
+        if (certificateConfiguration == null)
+        {
+            return;
+        }
+
+        try
+        {
+            certificateConfiguration.Certificate.Dispose();
+        }
+        catch(Exception e)
+        {
+            _logger.LogInformation(e, "Error during disposing of certificate");
+        }
+        
+        try
+        {
+            certificateConfiguration.PrivateKey.Dispose();
+        }
+        catch(Exception e)
+        {
+            _logger.LogInformation(e, "Error during disposing of PrivateKey");
+        }
+    }
+}

--- a/SigningServer.Server/SigningServer.Server.csproj
+++ b/SigningServer.Server/SigningServer.Server.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="BouncyCastle.NetCore" Version="1.9.0" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.WindowsServices" Version="6.0.9" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="6.0.12" />
 		<PackageReference Include="NLog" Version="5.0.4" />
 		<PackageReference Include="NLog.Web.AspNetCore" Version="5.1.4" />
 		<PackageReference Include="NuGet.Packaging" Version="6.3.0" />

--- a/SigningServer.Server/Startup.cs
+++ b/SigningServer.Server/Startup.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.ObjectPool;
 using SigningServer.Android.Collections;
 using SigningServer.Server.Configuration;
 using SigningServer.Server.SigningTool;
@@ -35,6 +36,8 @@ public class Startup
         services.AddTransient<IHostedService>(sp => sp.GetRequiredService<HardwareCertificateUnlocker>());
         services.AddSingleton<ISigningToolProvider, DefaultSigningToolProvider>();
         services.AddSingleton<IHashSigningTool, ManagedHashSigningTool>();
+        services.AddSingleton<ICertificateProvider, PooledCertificateProvider>();
+        services.AddSingleton<ObjectPoolProvider, DefaultObjectPoolProvider>();
         services.Configure<FormOptions>(x =>
         {
             x.ValueLengthLimit = int.MaxValue;

--- a/SigningServer.Server/appsettings.json
+++ b/SigningServer.Server/appsettings.json
@@ -17,7 +17,7 @@
         "LocalStore": {
           "StoreName": "My",
           "StoreLocation": "CurrentUser",
-          "Thumbprint": "2a106a052c46affa7dd684b4078a6d3c5275a81a"
+          "Thumbprint": "be97e29ee1e057d4f3f0f07b9539a166768454a0"
         }
       }
     ]

--- a/SigningServer.Test/SigningControllerSigningTest.cs
+++ b/SigningServer.Test/SigningControllerSigningTest.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SigningServer.Core;
+using SigningServer.Server;
 using SigningServer.Server.Configuration;
 using SigningServer.Server.Controllers;
 using SigningServer.Server.Dtos;
@@ -64,7 +65,7 @@ public class SigningControllerSigningTest : UnitTestBase
     public async Task SignFile_EmptyFile_Fails()
     {
         var server = new SigningController(AssemblyEvents.LoggerProvider.CreateLogger<SigningController>(),
-            _emptySigningToolProvider, null, _configuration)
+            _emptySigningToolProvider, null, _configuration, new NonPooledCertificateProvider(_configuration))
         {
             ControllerContext = CreateEmptyControllerContext()
         };
@@ -100,7 +101,7 @@ public class SigningControllerSigningTest : UnitTestBase
         };
 
         var server = new SigningController(AssemblyEvents.LoggerProvider.CreateLogger<SigningController>(),
-            _emptySigningToolProvider, null, configuration)
+            _emptySigningToolProvider, null, configuration, new NonPooledCertificateProvider(configuration))
         {
             ControllerContext = CreateEmptyControllerContext()
         };
@@ -132,7 +133,7 @@ public class SigningControllerSigningTest : UnitTestBase
     public async Task SignFile_UnsupportedFormat_Fails()
     {
         var server = new SigningController(AssemblyEvents.LoggerProvider.CreateLogger<SigningController>(),
-            _emptySigningToolProvider, null, _configuration)
+            _emptySigningToolProvider, null, _configuration, new NonPooledCertificateProvider(_configuration))
         {
             ControllerContext = CreateEmptyControllerContext()
         };
@@ -153,7 +154,7 @@ public class SigningControllerSigningTest : UnitTestBase
     public async Task SignFile_UploadsFileToWorkingDirectory()
     {
         var server = new SigningController(AssemblyEvents.LoggerProvider.CreateLogger<SigningController>(),
-            _simulateSigningToolProvider, null, _configuration)
+            _simulateSigningToolProvider, null, _configuration, new NonPooledCertificateProvider(_configuration))
         {
             ControllerContext = CreateEmptyControllerContext()
         };


### PR DESCRIPTION
We experience regular errors from Windows with simply " An internal error occurred. HR[-2146893792]". This change attempts to recreate/reload certificates in case signing fails with a loaded instance. It relies on the client side retry. 