### PR TITLE
Change formats of certificate loading

### DIFF
--- a/SigningServer.Client/Program.cs
+++ b/SigningServer.Client/Program.cs
@@ -2,11 +2,11 @@
 using System.IO;
 using System.Linq;
 using System.Net.Http;
-using System.Security.Cryptography.X509Certificates;
 using System.Text.Json;
 using System.Threading.Tasks;
 using NLog;
 using NLog.Targets;
+using SigningServer.Core;
 
 namespace SigningServer.Client;
 
@@ -91,13 +91,8 @@ internal class Program
             Console.WriteLine("      Instead of signing files a certificate file containing the public key will be downloaded");
             Console.WriteLine("      to the specified path. Can be combined with other operations");
             Console.WriteLine("      Format: ");
-            Console.WriteLine("        - \"Authenticode\" - An Authenticode X.509 certificate.");
-            Console.WriteLine("        - \"Cert\" - A single X.509 certificate.");
-            Console.WriteLine("        - \"Pfx\" - A PFX-formatted certificate.");
-            Console.WriteLine("        - \"Pkcs12\" - A PKCS #12-formatted certificate.");
-            Console.WriteLine("        - \"Pkcs7\" - A PKCS #7-formatted certificate.");
-            Console.WriteLine("        - \"SerializedCert\" - A single serialized X.509 certificate.");
-            Console.WriteLine("        - \"SerializedStore\" - A serialized store.");
+            Console.WriteLine("        - \"Pem\" - A PEM encoded file");
+            Console.WriteLine("        - \"Pkcs12\" - A Pkcs12 encoded file (aka. PFX).");
 
             Console.WriteLine("  --load-certificate-chain Format");
             Console.WriteLine("      Like --load-certificate but the whole certificate chian will be downloaded.");
@@ -359,8 +354,8 @@ internal class Program
                         if (i + 2 < args.Length)
                         {
                             i++;
-                            if (!Enum.TryParse(typeof(X509ContentType), args[i], true, out var p) ||
-                                p is not X509ContentType contentType)
+                            if (!Enum.TryParse(typeof(LoadCertificateFormat), args[i], true, out var p) ||
+                                p is not LoadCertificateFormat contentType)
                             {
                                 log.Error("Config could not be loaded: Invalid certificate format");
                                 Environment.ExitCode = ErrorCodes.InvalidConfiguration;
@@ -383,8 +378,8 @@ internal class Program
                         if (i + 2 < args.Length)
                         {
                             i++;
-                            if (!Enum.TryParse(typeof(X509ContentType), args[i], out var p) ||
-                                p is not X509ContentType contentType)
+                            if (!Enum.TryParse(typeof(LoadCertificateFormat), args[i], out var p) ||
+                                p is not LoadCertificateFormat contentType)
                             {
                                 log.Error("Config could not be loaded: Invalid certificate format");
                                 Environment.ExitCode = ErrorCodes.InvalidConfiguration;

--- a/SigningServer.Client/SigningClientConfiguration.cs
+++ b/SigningServer.Client/SigningClientConfiguration.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
-using System.Security.Cryptography.X509Certificates;
 using System.Text.Json.Serialization;
+using SigningServer.Core;
 
 namespace SigningServer.Client;
 
@@ -85,5 +85,5 @@ public class SigningClientConfiguration
     /// <summary>
     /// If a certificate download should be performed, the format to download.
     /// </summary>
-    public X509ContentType? LoadCertificateExportFormat { get; set; }
+    public LoadCertificateFormat? LoadCertificateExportFormat { get; set; }
 }

--- a/SigningServer.Core/LoadCertificateResponseStatus.cs
+++ b/SigningServer.Core/LoadCertificateResponseStatus.cs
@@ -1,6 +1,25 @@
 ﻿namespace SigningServer.Core;
 
 /// <summary>
+/// Lists the different formats to load the certificate
+/// </summary>
+public enum LoadCertificateFormat
+{
+    /// <summary>
+    /// A PEM encoded file with the whole certificate (CERTIFICATE sections)
+    /// </summary>
+    PemCertificate,
+    /// <summary>
+    /// A PEM encoded file with the public keys only (PUBLIC KEY sections)
+    /// </summary>
+    PemPublicKey,
+    /// <summary>
+    /// A Pkcs12 (aka. PFX) container.
+    /// </summary>
+    Pkcs12
+}
+
+/// <summary>
 /// Lists all possible result status codes of a certificate loading operation.
 /// </summary>
 public enum LoadCertificateResponseStatus

--- a/SigningServer.Server/Dtos/LoadCertificateRequestDto.cs
+++ b/SigningServer.Server/Dtos/LoadCertificateRequestDto.cs
@@ -1,4 +1,5 @@
-using System.Security.Cryptography.X509Certificates;
+
+using SigningServer.Core;
 
 namespace SigningServer.Server.Dtos;
 
@@ -17,7 +18,7 @@ public class LoadCertificateRequestDto
     /// <summary>
     /// The format into which the certificates will be encoded.
     /// </summary>
-    public X509ContentType ExportFormat { get; set; }
+    public LoadCertificateFormat ExportFormat { get; set; }
 
     /// <summary>
     /// Whether to include the full certificate chain.


### PR DESCRIPTION
Change the formats of certificate loading to more common PEM and Pkcs12 due to limitations on the normal export of X509Certificate2. 