### PR TITLE
feat: Add feature to remember signed files and avoid duplicate requests

### DIFF
--- a/SigningServer.Client/Program.cs
+++ b/SigningServer.Client/Program.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.EnvironmentVariables;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -31,6 +32,11 @@ internal static class Program
             })
             .ConfigureAppConfiguration(config =>
             {
+                foreach (var envSources in config.Sources.OfType<EnvironmentVariablesConfigurationSource>().ToArray())
+                {
+                    config.Sources.Remove(envSources);
+                }
+                config.AddEnvironmentVariables("SIGNINGSERVER_CLIENT_");
                 config.AddJsonFile("config.json", optional: true);
             })
             .ConfigureServices(services =>

--- a/SigningServer.Client/SigningClientConfiguration.cs
+++ b/SigningServer.Client/SigningClientConfiguration.cs
@@ -14,6 +14,8 @@ public class SigningClientConfiguration : SigningClientConfigurationBase
     /// </summary>
     public string SigningServer { get; set; } = string.Empty;
 
+    public override string CredentialInfo => Username;
+
     /// <summary>
     /// The username for authentication and cerificate selection.
     /// </summary>

--- a/SigningServer.ClientCore/Configuration/DefaultSigningConfigurationLoader.cs
+++ b/SigningServer.ClientCore/Configuration/DefaultSigningConfigurationLoader.cs
@@ -58,7 +58,15 @@ public class DefaultSigningConfigurationLoader<TConfiguration> : ISigningConfigu
                 _logger.LogTrace("Loading config.json");
                 configuration =
                     JsonSerializer.Deserialize<TConfiguration>(
-                        await File.ReadAllTextAsync(defaultConfigFilePath))!;
+                        await File.ReadAllTextAsync(defaultConfigFilePath),
+                        new JsonSerializerOptions
+                        {
+                            PropertyNameCaseInsensitive = true,
+                            Converters =
+                            {
+                                new JsonStringEnumConverter()
+                            }
+                        })!;
                 _logger.LogTrace("Configuration loaded from config.json");
                 return configuration;
             }

--- a/SigningServer.ClientCore/SigningClient.cs
+++ b/SigningServer.ClientCore/SigningClient.cs
@@ -131,7 +131,7 @@ public abstract class SigningClient<TConfiguration> : IDisposable, ISigningClien
                 var error = $"Certificate Loading Failed with error '{responseDto.ErrorMessage}'";
                 throw new SigningFailedException(error);
             case LoadCertificateResponseStatus.CertificateNotLoadedUnauthorized:
-                Logger.LogError("The specified username and password are not recognized on the server");
+                Logger.LogError("The specified username and password are not recognized on the server ({Status}, {Username})", responseDto.Status, Configuration.CredentialInfo);
                 throw new UnauthorizedAccessException();
             default:
                 throw new ArgumentOutOfRangeException();
@@ -194,7 +194,7 @@ public abstract class SigningClient<TConfiguration> : IDisposable, ISigningClien
                             $"Signing Failed with error '{responseDto.ErrorMessage}' (sign time: {responseDto.SignTimeInMilliseconds:0}ms)";
                         throw new SigningFailedException(error);
                     case SignHashResponseStatus.HashNotSignedUnauthorized:
-                        Logger.LogError("The specified username and password are not recognized on the server");
+                        Logger.LogError("The specified username and password are not recognized on the server ({Status}, {Username})", responseDto.Status, Configuration.CredentialInfo);
                         throw new UnauthorizedAccessException();
                     default:
                         throw new ArgumentOutOfRangeException();
@@ -341,7 +341,7 @@ public abstract class SigningClient<TConfiguration> : IDisposable, ISigningClien
                                 $"Signing Failed with error '{errorMessage}' (upload time: {uploadTime.TotalMilliseconds:0}ms, sign time: {signTime.TotalMilliseconds:0}ms)";
                             throw new SigningFailedException(error);
                         case SignFileResponseStatus.FileNotSignedUnauthorized:
-                            Logger.LogError("The specified username and password are not recognized on the server");
+                            Logger.LogError("The specified username and password are not recognized on the server ({Status}, {Username})", status, Configuration.CredentialInfo);
                             throw new UnauthorizedAccessException();
                         default:
                             throw new ArgumentOutOfRangeException();

--- a/SigningServer.ClientCore/SigningClientConfiguration.cs
+++ b/SigningServer.ClientCore/SigningClientConfiguration.cs
@@ -8,6 +8,13 @@ using SigningServer.Core;
 
 namespace SigningServer.ClientCore;
 
+public enum DuplicateFileDetectionMode
+{
+    None,
+    ByFileName,
+    ByFileHash
+}
+
 /// <summary>
 /// Represents the signing client 
 /// </summary>
@@ -90,6 +97,11 @@ public abstract class SigningClientConfigurationBase
     /// If a certificate download should be performed, the format to download.
     /// </summary>
     public LoadCertificateFormat? LoadCertificateExportFormat { get; set; }
+
+    /// <summary>
+    /// Whether to detect duplicate files being side.
+    /// </summary>
+    public DuplicateFileDetectionMode DuplicateFileDetection { get; set; } = DuplicateFileDetectionMode.None;
 
     public virtual bool FillFromArgs(string[] args, ILogger log)
     {

--- a/SigningServer.ClientCore/SigningClientConfiguration.cs
+++ b/SigningServer.ClientCore/SigningClientConfiguration.cs
@@ -11,8 +11,18 @@ namespace SigningServer.ClientCore;
 /// <summary>
 /// Represents the signing client 
 /// </summary>
-public class SigningClientConfigurationBase
+public abstract class SigningClientConfigurationBase
 {
+    /// <summary>
+    /// Whether to execute signing or not, useful if you have to enable/disable signing temporarily.
+    /// </summary>
+    public bool IsSigningDisabled { get; set; }
+
+    /// <summary>
+    /// Gets the credential info to use for authentication and certificate selection.
+    /// </summary>
+    public abstract string CredentialInfo { get; }
+    
     /// <summary>
     /// Whether to overwrite existing signatures or fail when signatures are present.
     /// </summary>

--- a/SigningServer.ClientCore/SigningClientRunner.cs
+++ b/SigningServer.ClientCore/SigningClientRunner.cs
@@ -37,6 +37,12 @@ public class SigningClientRunner<TConfiguration>
             return;
         }
 
+        if (configuration.IsSigningDisabled)
+        {
+            _logger.LogWarning("Signing was disabled by configuration");
+            return;
+        }
+
         foreach (var source in configuration.Sources)
         {
             if (!File.Exists(source) && !Directory.Exists(source))

--- a/SigningServer.StandaloneClient/Program.cs
+++ b/SigningServer.StandaloneClient/Program.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.EnvironmentVariables;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -32,6 +33,11 @@ internal static class Program
             })
             .ConfigureAppConfiguration(config =>
             {
+                foreach (var envSources in config.Sources.OfType<EnvironmentVariablesConfigurationSource>().ToArray())
+                {
+                    config.Sources.Remove(envSources);
+                }
+                config.AddEnvironmentVariables("SIGNINGSERVER_CLIENT_");
                 config.AddJsonFile("config.json", optional: true);
             })
             .ConfigureServices(services =>

--- a/SigningServer.StandaloneClient/StandaloneSigningClientConfiguration.cs
+++ b/SigningServer.StandaloneClient/StandaloneSigningClientConfiguration.cs
@@ -21,6 +21,8 @@ public class StandaloneSigningClientConfiguration : SigningClientConfigurationBa
 {
     public ServerType ServerType { get; set; }
 
+    public override string CredentialInfo => "local";
+
     /// <summary>
     /// A RFC-3161 compliant timestamping server which should be used.
     /// </summary>


### PR DESCRIPTION
If you sign compile outputs (e.g. in .net) it can easily happen that the same binaries are within the multiple folders. With this change the signign client can remember the files and instead of issuing additional signing requests, it takes the signed binary it already has locally. 
