### PR TITLE
feat: Multi-Credentials for Certs and Auditing

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -1,0 +1,8 @@
+﻿# Breaking Changes
+
+This document tries to list out breaking changes between versions 
+
+## 2.x.x -> 3.0.0
+
+* Certificates now can have a name attached for logging and reporting purposes via `CertificateName`, this should be set for all certificates.
+* Previously certificates had only one username+password pair to be selected. For more fine-grained access control and auditing purposes, every certificate defines now the credentials in a `Credentials` list in the configuration.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
 
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <BuildNumber Condition=" '$(BuildNumber)' == '' ">0</BuildNumber>
-    <VersionPrefix>2.1.0</VersionPrefix>
+    <VersionPrefix>3.0.0</VersionPrefix>
     <FileVersion>$(VersionPrefix).$(BuildNumber)</FileVersion>
     <Company>Daniel Kuschny</Company>
     <Copyright>Copyright © 2023 Daniel Kuschny</Copyright>

--- a/README.md
+++ b/README.md
@@ -78,10 +78,14 @@ specific settings are nested in the `"SigningServer` key.
                 // Can be removed or left empty for the default certificate
                 // which should be used in case the client does not supply credentials.
                 // There can only be one certificate without username and password 
-
-                "Username": "", // The plain text username to use this certificate
-                "Password": "", // The plain text password to use this certificate
-
+                "CertificateName": "MyCodeSigningCert", // The name used in logging and reporting areas
+                // A list of credentials which can be used to select this certificate,
+                // Leave this empty or add a item with username and password set to empty 
+                // To use it as default certificate 
+                "Credentials": [
+                  { "Username": "", "Password": "" }, // default when no credentials are supplied
+                  { "Username": "team01", "Password": "teampass01" } // designated credentials for a team                  
+                ],
                 "Local": {
                     "Thumbprint": "", // The thumbprint of the certificate to load
                     "StoreName": "", // The name of the certificate store to access (AddressBook, AuthRoot, CertificateAuthority, Disallowed, My, Root, TrustedPeople, TrustedPublisher)
@@ -98,8 +102,10 @@ specific settings are nested in the `"SigningServer` key.
             // Example for a certificate from an Azure KeyVault
             {
                 // Same as for local certificates
-                "Username": "azure-keyvault",
-                "Password": "azure-keyvault",
+                "CertificateName": "KeyVaultCert",
+                "Credentials": [
+                  { "Username": "azure-keyvault", "Password": "azure-keyvault" }                  
+                ],
 
                 // Azure specific configuration
                 "Azure": {

--- a/SigningServer.Client/Program.cs
+++ b/SigningServer.Client/Program.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.EnvironmentVariables;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -31,6 +32,11 @@ internal static class Program
             })
             .ConfigureAppConfiguration(config =>
             {
+                foreach (var envSources in config.Sources.OfType<EnvironmentVariablesConfigurationSource>().ToArray())
+                {
+                    config.Sources.Remove(envSources);
+                }
+                config.AddEnvironmentVariables("SIGNINGSERVER_CLIENT_");
                 config.AddJsonFile("config.json", optional: true);
             })
             .ConfigureServices(services =>

--- a/SigningServer.Client/SigningClientConfiguration.cs
+++ b/SigningServer.Client/SigningClientConfiguration.cs
@@ -14,6 +14,8 @@ public class SigningClientConfiguration : SigningClientConfigurationBase
     /// </summary>
     public string SigningServer { get; set; } = string.Empty;
 
+    public override string CredentialInfo => Username;
+
     /// <summary>
     /// The username for authentication and cerificate selection.
     /// </summary>

--- a/SigningServer.ClientCore/Configuration/DefaultSigningConfigurationLoader.cs
+++ b/SigningServer.ClientCore/Configuration/DefaultSigningConfigurationLoader.cs
@@ -58,7 +58,15 @@ public class DefaultSigningConfigurationLoader<TConfiguration> : ISigningConfigu
                 _logger.LogTrace("Loading config.json");
                 configuration =
                     JsonSerializer.Deserialize<TConfiguration>(
-                        await File.ReadAllTextAsync(defaultConfigFilePath))!;
+                        await File.ReadAllTextAsync(defaultConfigFilePath),
+                        new JsonSerializerOptions
+                        {
+                            PropertyNameCaseInsensitive = true,
+                            Converters =
+                            {
+                                new JsonStringEnumConverter()
+                            }
+                        })!;
                 _logger.LogTrace("Configuration loaded from config.json");
                 return configuration;
             }

--- a/SigningServer.ClientCore/SigningClient.cs
+++ b/SigningServer.ClientCore/SigningClient.cs
@@ -131,7 +131,7 @@ public abstract class SigningClient<TConfiguration> : IDisposable, ISigningClien
                 var error = $"Certificate Loading Failed with error '{responseDto.ErrorMessage}'";
                 throw new SigningFailedException(error);
             case LoadCertificateResponseStatus.CertificateNotLoadedUnauthorized:
-                Logger.LogError("The specified username and password are not recognized on the server");
+                Logger.LogError("The specified username and password are not recognized on the server ({Status}, {Username})", responseDto.Status, Configuration.CredentialInfo);
                 throw new UnauthorizedAccessException();
             default:
                 throw new ArgumentOutOfRangeException();
@@ -194,7 +194,7 @@ public abstract class SigningClient<TConfiguration> : IDisposable, ISigningClien
                             $"Signing Failed with error '{responseDto.ErrorMessage}' (sign time: {responseDto.SignTimeInMilliseconds:0}ms)";
                         throw new SigningFailedException(error);
                     case SignHashResponseStatus.HashNotSignedUnauthorized:
-                        Logger.LogError("The specified username and password are not recognized on the server");
+                        Logger.LogError("The specified username and password are not recognized on the server ({Status}, {Username})", responseDto.Status, Configuration.CredentialInfo);
                         throw new UnauthorizedAccessException();
                     default:
                         throw new ArgumentOutOfRangeException();
@@ -341,7 +341,7 @@ public abstract class SigningClient<TConfiguration> : IDisposable, ISigningClien
                                 $"Signing Failed with error '{errorMessage}' (upload time: {uploadTime.TotalMilliseconds:0}ms, sign time: {signTime.TotalMilliseconds:0}ms)";
                             throw new SigningFailedException(error);
                         case SignFileResponseStatus.FileNotSignedUnauthorized:
-                            Logger.LogError("The specified username and password are not recognized on the server");
+                            Logger.LogError("The specified username and password are not recognized on the server ({Status}, {Username})", status, Configuration.CredentialInfo);
                             throw new UnauthorizedAccessException();
                         default:
                             throw new ArgumentOutOfRangeException();

--- a/SigningServer.ClientCore/SigningClientConfiguration.cs
+++ b/SigningServer.ClientCore/SigningClientConfiguration.cs
@@ -8,6 +8,13 @@ using SigningServer.Core;
 
 namespace SigningServer.ClientCore;
 
+public enum DuplicateFileDetectionMode
+{
+    None,
+    ByFileName,
+    ByFileHash
+}
+
 /// <summary>
 /// Represents the signing client 
 /// </summary>
@@ -90,6 +97,11 @@ public abstract class SigningClientConfigurationBase
     /// If a certificate download should be performed, the format to download.
     /// </summary>
     public LoadCertificateFormat? LoadCertificateExportFormat { get; set; }
+
+    /// <summary>
+    /// Whether to detect duplicate files being side.
+    /// </summary>
+    public DuplicateFileDetectionMode DuplicateFileDetection { get; set; } = DuplicateFileDetectionMode.None;
 
     public virtual bool FillFromArgs(string[] args, ILogger log)
     {

--- a/SigningServer.ClientCore/SigningClientConfiguration.cs
+++ b/SigningServer.ClientCore/SigningClientConfiguration.cs
@@ -11,8 +11,18 @@ namespace SigningServer.ClientCore;
 /// <summary>
 /// Represents the signing client 
 /// </summary>
-public class SigningClientConfigurationBase
+public abstract class SigningClientConfigurationBase
 {
+    /// <summary>
+    /// Whether to execute signing or not, useful if you have to enable/disable signing temporarily.
+    /// </summary>
+    public bool IsSigningDisabled { get; set; }
+
+    /// <summary>
+    /// Gets the credential info to use for authentication and certificate selection.
+    /// </summary>
+    public abstract string CredentialInfo { get; }
+    
     /// <summary>
     /// Whether to overwrite existing signatures or fail when signatures are present.
     /// </summary>

--- a/SigningServer.ClientCore/SigningClientRunner.cs
+++ b/SigningServer.ClientCore/SigningClientRunner.cs
@@ -37,6 +37,12 @@ public class SigningClientRunner<TConfiguration>
             return;
         }
 
+        if (configuration.IsSigningDisabled)
+        {
+            _logger.LogWarning("Signing was disabled by configuration");
+            return;
+        }
+
         foreach (var source in configuration.Sources)
         {
             if (!File.Exists(source) && !Directory.Exists(source))

--- a/SigningServer.Server/Configuration/SigningServerConfiguration.cs
+++ b/SigningServer.Server/Configuration/SigningServerConfiguration.cs
@@ -11,6 +11,11 @@ public class SigningServerConfiguration
     public int HardwareCertificateUnlockIntervalInSeconds { get; set; }
 
     /// <summary>
+    /// The interval how often the cached signing request audit information should be flushed to disk.
+    /// </summary>
+    public TimeSpan AuditFlushInterval { get; set; } = TimeSpan.FromMinutes(1);
+    
+    /// <summary>
     /// A RFC-3161 compliant timestamping server which should be used.
     /// </summary>
     public string TimestampServer { get; set; } = string.Empty;

--- a/SigningServer.Server/Configuration/SigningServerConfiguration.cs
+++ b/SigningServer.Server/Configuration/SigningServerConfiguration.cs
@@ -31,6 +31,7 @@ public class SigningServerConfiguration
     public string WorkingDirectory { get; set; } = string.Empty;
 
     public CertificateConfiguration[] Certificates { get; set; } = Array.Empty<CertificateConfiguration>();
+    public CertificateAccessCredentials[] AccessTokens { get; set; } = Array.Empty<CertificateAccessCredentials>();
 
     /// <summary>
     /// The maximum degree of parallelism allowed per individual client.

--- a/SigningServer.Server/Controllers/SigningController.cs
+++ b/SigningServer.Server/Controllers/SigningController.cs
@@ -85,7 +85,7 @@ public class SigningController : Controller
         string inputFileName;
         ICertificateAccessor? certificate = null;
 
-        var userInfo = (signFileRequest.Username ?? "unknown");
+        var userInfo = signFileRequest.Username ?? "unknown";
         
         try
         {
@@ -113,7 +113,7 @@ public class SigningController : Controller
                 return new SignFileActionResult(apiSignFileResponse, null);
             }
             
-            userInfo += "-" + certificate.CertificateName;
+            userInfo = certificate.Credentials.DisplayName + "-" + certificate.CertificateName;
 
             // 
             // find compatible signing tool
@@ -259,7 +259,7 @@ public class SigningController : Controller
     {
         var remoteIp = RemoteIp;
         var certificate = _certificateProvider.Get(signHashRequestDto.Username, signHashRequestDto.Password);
-        var userInfo = (signHashRequestDto.Username ?? "unknown");
+        var userInfo = signHashRequestDto.Username ?? "unknown";
         try
         {
             //
@@ -294,7 +294,7 @@ public class SigningController : Controller
                 ));
             }
             
-            userInfo += certificate.CertificateName;
+            userInfo = certificate.Credentials.DisplayName + "-" + certificate.CertificateName;
 
             var stopwatch = Stopwatch.StartNew();
             stopwatch.Restart();

--- a/SigningServer.Server/Controllers/SigningController.cs
+++ b/SigningServer.Server/Controllers/SigningController.cs
@@ -7,7 +7,6 @@ using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using SigningServer.Core;
@@ -15,7 +14,6 @@ using SigningServer.Dtos;
 using SigningServer.Server.Configuration;
 using SigningServer.Server.Util;
 using SigningServer.Signing;
-using SigningServer.Signing.Configuration;
 using SignFileRequestDto = SigningServer.Server.Dtos.SignFileRequestDto;
 using SignFileResponseDto = SigningServer.Server.Dtos.SignFileResponseDto;
 
@@ -33,19 +31,22 @@ public class SigningController : Controller
     private readonly IHashSigningTool _hashSigningTool;
     private readonly SigningServerConfiguration _configuration;
     private readonly ICertificateProvider _certificateProvider;
+    private readonly ISigningRequestTracker _signingRequestTracker;
 
     public SigningController(
         ILogger<SigningController> logger,
         ISigningToolProvider signingToolProvider,
         IHashSigningTool hashSigningTool,
         SigningServerConfiguration configuration,
-        ICertificateProvider certificateProvider)
+        ICertificateProvider certificateProvider,
+        ISigningRequestTracker signingRequestTracker)
     {
         _logger = logger;
         _signingToolProvider = signingToolProvider;
         _hashSigningTool = hashSigningTool;
         _configuration = configuration;
         _certificateProvider = certificateProvider;
+        _signingRequestTracker = signingRequestTracker;
     }
 
     /// <summary>
@@ -82,7 +83,10 @@ public class SigningController : Controller
         SignFileResponse? coreSignFileResponse = null;
         var remoteIp = RemoteIp;
         string inputFileName;
-        Lazy<ValueTask<CertificateConfiguration>>? certificate = null;
+        ICertificateAccessor? certificate = null;
+
+        var userInfo = (signFileRequest.Username ?? "unknown");
+        
         try
         {
             var stopwatch = Stopwatch.StartNew();
@@ -94,6 +98,7 @@ public class SigningController : Controller
             {
                 apiSignFileResponse.Status = SignFileResponseStatus.FileNotSignedError;
                 apiSignFileResponse.ErrorMessage = "No file was received";
+                await _signingRequestTracker.TrackRequestAsync(userInfo, apiSignFileResponse.Status, 0);
                 return new SignFileActionResult(apiSignFileResponse, null);
             }
 
@@ -104,8 +109,11 @@ public class SigningController : Controller
             {
                 _logger.LogWarning("Unauthorized signing request");
                 apiSignFileResponse.Status = SignFileResponseStatus.FileNotSignedUnauthorized;
+                await _signingRequestTracker.TrackRequestAsync(userInfo, apiSignFileResponse.Status, 1);
                 return new SignFileActionResult(apiSignFileResponse, null);
             }
+            
+            userInfo += "-" + certificate.CertificateName;
 
             // 
             // find compatible signing tool
@@ -114,6 +122,7 @@ public class SigningController : Controller
             {
                 apiSignFileResponse.Status = SignFileResponseStatus.FileNotSignedUnsupportedFormat;
                 await _certificateProvider.ReturnAsync(signFileRequest.Username, certificate);
+                await _signingRequestTracker.TrackRequestAsync(userInfo, apiSignFileResponse.Status, 1);
                 return new SignFileActionResult(apiSignFileResponse, null);
             }
 
@@ -177,8 +186,8 @@ public class SigningController : Controller
             coreSignFileResponse = await signingTool.SignFileAsync(
                 new SignFileRequest(
                     inputFileName,
-                    new Lazy<ValueTask<X509Certificate2>>(async () => (await certificate.Value).Certificate!),
-                    new Lazy<ValueTask<AsymmetricAlgorithm>>(async () => (await certificate.Value).PrivateKey!),
+                    new Lazy<ValueTask<X509Certificate2>>(async () => (await certificate.UseCertificate()).Certificate!),
+                    new Lazy<ValueTask<AsymmetricAlgorithm>>(async () => (await certificate.UseCertificate()).PrivateKey!),
                     signFileRequest.FileToSign.FileName,
                     timestampServer,
                     signFileRequest.HashAlgorithm,
@@ -217,6 +226,7 @@ public class SigningController : Controller
 
             apiSignFileResponse.ErrorMessage = coreSignFileResponse.ErrorMessage;
             apiSignFileResponse.Status = coreSignFileResponse.Status;
+            await _signingRequestTracker.TrackRequestAsync(userInfo, apiSignFileResponse.Status, coreSignFileResponse.ResultFiles?.Count ?? 1);
 
             stopwatch.Stop();
             apiSignFileResponse.SignTimeInMilliseconds = stopwatch.ElapsedMilliseconds + preparationTime;
@@ -232,6 +242,7 @@ public class SigningController : Controller
                 $"[{remoteIp}] Signing of '{signFileRequest.FileToSign?.Name}' failed: {e.Message} HR[{e.HResult}");
             apiSignFileResponse.Status = SignFileResponseStatus.FileNotSignedError;
             apiSignFileResponse.ErrorMessage = e.Message;
+            await _signingRequestTracker.TrackRequestAsync(userInfo, apiSignFileResponse.Status, coreSignFileResponse?.ResultFiles?.Count ?? 1);
         }
 
         return new SignFileActionResult(apiSignFileResponse, coreSignFileResponse?.ResultFiles);
@@ -248,6 +259,7 @@ public class SigningController : Controller
     {
         var remoteIp = RemoteIp;
         var certificate = _certificateProvider.Get(signHashRequestDto.Username, signHashRequestDto.Password);
+        var userInfo = (signHashRequestDto.Username ?? "unknown");
         try
         {
             //
@@ -261,6 +273,7 @@ public class SigningController : Controller
             }
             catch
             {
+                await _signingRequestTracker.TrackRequestAsync(userInfo, SignFileResponseStatus.FileNotSignedError, 1);
                 return new SignHashActionResult(new SignHashResponseDto(
                     SignHashResponseStatus.HashNotSignedError,
                     0,
@@ -280,6 +293,8 @@ public class SigningController : Controller
                     string.Empty
                 ));
             }
+            
+            userInfo += certificate.CertificateName;
 
             var stopwatch = Stopwatch.StartNew();
             stopwatch.Restart();
@@ -288,8 +303,8 @@ public class SigningController : Controller
             // sign hash
             var coreSignFileResponse = _hashSigningTool.SignHash(new SignHashRequest(
                 hashBytes,
-                (await certificate.Value).Certificate!,
-                (await certificate.Value).PrivateKey!,
+                (await certificate.UseCertificate()).Certificate!,
+                (await certificate.UseCertificate()).PrivateKey!,
                 signHashRequestDto.HashAlgorithm,
                 signHashRequestDto.PaddingMode
             ));
@@ -304,7 +319,17 @@ public class SigningController : Controller
 
             // only return when signed
             await _certificateProvider.ReturnAsync(signHashRequestDto.Username, certificate);
-
+            var trackingStatus = coreSignFileResponse.Status switch
+            {
+                SignHashResponseStatus.HashSigned => SignFileResponseStatus.FileSigned,
+                SignHashResponseStatus.HashNotSignedUnsupportedFormat => SignFileResponseStatus
+                    .FileNotSignedUnsupportedFormat,
+                SignHashResponseStatus.HashNotSignedError => SignFileResponseStatus.FileNotSignedError,
+                SignHashResponseStatus.HashNotSignedUnauthorized => SignFileResponseStatus.FileNotSignedUnauthorized,
+                _ => SignFileResponseStatus.FileNotSignedError
+            };
+            await _signingRequestTracker.TrackRequestAsync(userInfo, trackingStatus, 1);
+            
             _logger.LogInformation(
                 $"[{remoteIp}] [Finished] request for hash '{signHashRequestDto.Hash}' finished ({signHashRequestDto.HashAlgorithm}, signed in {stopwatch.ElapsedMilliseconds})");
 
@@ -314,89 +339,13 @@ public class SigningController : Controller
         {
             await _certificateProvider.DestroyAsync(certificate);
             _logger.LogError(e, $"[{remoteIp}] Signing of '{signHashRequestDto.Hash}' failed: {e.Message}");
+            await _signingRequestTracker.TrackRequestAsync(userInfo, SignFileResponseStatus.FileNotSignedError, 1);
             return new SignHashActionResult(new SignHashResponseDto(
                 SignHashResponseStatus.HashNotSignedError,
                 0,
                 e.Message,
                 string.Empty
             ));
-        }
-    }
-
-    /// <summary>
-    /// Decrypts the given data assuming an RSA encryption
-    /// </summary>
-    /// <param name="request"></param>
-    /// <returns></returns>
-    [HttpPost("decryptrsa")]
-    [Produces("application/json", Type = typeof(DecryptRsaResponseDto))]
-    public async Task<IActionResult> DecryptRsa([FromBody, Required] DecryptRsaRequestDto request)
-    {
-        var remoteIp = RemoteIp;
-        var certificate = _certificateProvider.Get(request.Username, request.Password);
-        ObjectResult result;
-        try
-        {
-            //
-            // validate input
-            _logger.LogInformation(
-                $"[{remoteIp}] [Begin] New decrypt of RSA data '{request.Data.Length}'");
-            byte[] dataBytes;
-            try
-            {
-                dataBytes = Convert.FromBase64String(request.Data);
-            }
-            catch
-            {
-                return new ObjectResult(new DecryptRsaResponseDto("No base64 encoded bytes were received", null))
-                {
-                    StatusCode = StatusCodes.Status400BadRequest
-                };
-            }
-
-            //
-            // find certificate
-            if (certificate == null)
-            {
-                return new ObjectResult(new DecryptRsaResponseDto("Unauthorized signing request", null))
-                {
-                    StatusCode = StatusCodes.Status401Unauthorized
-                };
-            }
-
-            var stopwatch = Stopwatch.StartNew();
-            stopwatch.Restart();
-
-            var certificateValue = await certificate.Value;
-            if (certificateValue.PrivateKey is RSA rsa)
-            {
-                var decrypted = rsa.Decrypt(dataBytes, request.ToPadding());
-                result = new ObjectResult(new DecryptRsaResponseDto(null, Convert.ToBase64String(decrypted)));
-            }
-            else
-            {
-                return new ObjectResult(new DecryptRsaResponseDto("Certificate is not RSA", null))
-                {
-                    StatusCode = StatusCodes.Status400BadRequest
-                };
-            }
-
-            // only return when signed
-            await _certificateProvider.ReturnAsync(request.Username, certificate);
-
-            _logger.LogInformation(
-                $"[{remoteIp}] [Finished] request for RSA decrypt '{request.Data.Length}' finished, signed in {stopwatch.ElapsedMilliseconds})");
-
-            return result;
-        }
-        catch (Exception e)
-        {
-            await _certificateProvider.DestroyAsync(certificate);
-            _logger.LogError(e, $"[{remoteIp}] Signing of '{request.Data}' failed: {e.Message}");
-            return new ObjectResult(new DecryptRsaResponseDto("Signing failed: " + e.Message, null))
-            {
-                StatusCode = StatusCodes.Status500InternalServerError
-            };
         }
     }
 
@@ -425,7 +374,7 @@ public class SigningController : Controller
 
             try
             {
-                var certificateValue = await certificate.Value;
+                var certificateValue = await certificate.UseCertificate();
                 if (loadCertificateRequestDto.IncludeChain)
                 {
                     using var ch = new X509Chain();

--- a/SigningServer.Server/ICertificateProvider.cs
+++ b/SigningServer.Server/ICertificateProvider.cs
@@ -11,6 +11,7 @@ namespace SigningServer.Server;
 /// </summary>
 public interface ICertificateAccessor
 {
+    public CertificateAccessCredentials Credentials { get; }
     public string CertificateName { get; }
     ValueTask<CertificateConfiguration> UseCertificate();
 }

--- a/SigningServer.Server/ICertificateProvider.cs
+++ b/SigningServer.Server/ICertificateProvider.cs
@@ -1,9 +1,19 @@
 ﻿using System;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using SigningServer.Server.Configuration;
 using SigningServer.Signing.Configuration;
 
 namespace SigningServer.Server;
+
+/// <summary>
+/// A certificate accessor to getting metadata or the certificate itself.
+/// </summary>
+public interface ICertificateAccessor
+{
+    public string CertificateName { get; }
+    ValueTask<CertificateConfiguration> UseCertificate();
+}
 
 /// <summary>
 /// Represents a provider for certificates to use during signing.
@@ -16,18 +26,18 @@ public interface ICertificateProvider
     /// <param name="username">The username to select the certificate</param>
     /// <param name="password">The password to select the certificate</param>
     /// <returns>A certificate configuration to use for signing</returns>
-    Lazy<ValueTask<CertificateConfiguration>>? Get(string? username, string? password);
+    ICertificateAccessor? Get(string? username, string? password);
     
     /// <summary>
     /// Returns a certificate for usage by another party. 
     /// </summary>
     /// <param name="username">The username this certificate belongs to.</param>
     /// <param name="certificateConfiguration">The certificate configuration to return</param>
-    ValueTask ReturnAsync(string? username, Lazy<ValueTask<CertificateConfiguration>> certificateConfiguration);
+    ValueTask ReturnAsync(string? username, ICertificateAccessor certificateConfiguration);
     
     /// <summary>
     /// Destroys the given certificate because it appears to not be usable anymore. 
     /// </summary>
     /// <param name="certificateConfiguration">The certificate to destroy.</param>
-    ValueTask DestroyAsync(Lazy<ValueTask<CertificateConfiguration>>? certificateConfiguration);
+    ValueTask DestroyAsync(ICertificateAccessor? certificateConfiguration);
 }

--- a/SigningServer.Server/ISigningRequestTracker.cs
+++ b/SigningServer.Server/ISigningRequestTracker.cs
@@ -1,0 +1,235 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using SigningServer.Core;
+using SigningServer.Server.Configuration;
+
+namespace SigningServer.Server;
+
+/// <summary>
+/// Represents the data model behind the singing request tracking logs where
+/// an aggregated information of requests are stored daily.
+/// </summary>
+public class SigningRequestTrackingLogFile
+{
+    public DateTime Date { get; set; }
+    public ConcurrentDictionary<string, SigningRequestTrackingLogFileEntry> Entries { get; set; } = new();
+
+    public void TrackRequest(string userInfo, SignFileResponseStatus status, int numberOfSignatures)
+    {
+        var userEntry = Entries.GetOrAdd(userInfo,
+            _ => new SigningRequestTrackingLogFileEntry { UserInfo = userInfo });
+
+        ulong totalNumberOfSignaturesCreated;
+        ulong totalNumberOfSignaturesSkipped;
+        switch (status)
+        {
+            case SignFileResponseStatus.FileSigned:
+            case SignFileResponseStatus.FileResigned:
+                totalNumberOfSignaturesCreated = (ulong)numberOfSignatures;
+                totalNumberOfSignaturesSkipped = 0ul;
+                break;
+            case SignFileResponseStatus.FileAlreadySigned:
+            case SignFileResponseStatus.FileNotSignedUnsupportedFormat:
+            case SignFileResponseStatus.FileNotSignedError:
+            case SignFileResponseStatus.FileNotSignedUnauthorized:
+                totalNumberOfSignaturesSkipped = (ulong)numberOfSignatures;
+                totalNumberOfSignaturesCreated = 0ul;
+                break;
+            default:
+                throw new ArgumentOutOfRangeException();
+        }
+
+        userEntry.Track(totalNumberOfSignaturesCreated, totalNumberOfSignaturesSkipped);
+    }
+}
+
+/// <summary>
+/// Represents the signing information of one specific user.
+/// </summary>
+public class SigningRequestTrackingLogFileEntry
+{
+    private ulong _totalNumberOfRequests;
+    private ulong _totalNumberOfSignaturesCreated;
+    private ulong _totalNumberOfSignaturesSkipped;
+    public string UserInfo { get; set; } = "";
+
+    public ulong TotalNumberOfRequests
+    {
+        get => _totalNumberOfRequests;
+        set => _totalNumberOfRequests = value;
+    }
+
+    public ulong TotalNumberOfSignaturesCreated
+    {
+        get => _totalNumberOfSignaturesCreated;
+        set => _totalNumberOfSignaturesCreated = value;
+    }
+
+    public ulong TotalNumberOfSignaturesSkipped
+    {
+        get => _totalNumberOfSignaturesSkipped;
+        set => _totalNumberOfSignaturesSkipped = value;
+    }
+
+    public void Track(
+        ulong totalNumberOfSignaturesCreated,
+        ulong totalNumberOfSignaturesSkipped)
+    {
+        Interlocked.Increment(ref _totalNumberOfRequests);
+        Interlocked.Add(ref _totalNumberOfSignaturesCreated, totalNumberOfSignaturesCreated);
+        Interlocked.Add(ref _totalNumberOfSignaturesSkipped, totalNumberOfSignaturesSkipped);
+    }
+}
+
+public interface ISigningRequestTracker
+{
+    Task TrackRequestAsync(
+        string userInfo,
+        SignFileResponseStatus status, int numberOfSignatures
+    );
+}
+
+/// <summary>
+/// A signing request tracker that persists the tracking data to disk via a background worker.
+/// It keeps an in-memory cache and is flushed regularly as configured.
+/// </summary>
+public class DiskPersistingSigningRequestTracker : ISigningRequestTracker, IDisposable
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true, Converters = { new JsonStringEnumConverter() }
+    };
+
+    private readonly SemaphoreSlim _currentDayLock = new(1, 1);
+    private SigningRequestTrackingLogFile? _currentDay;
+
+
+    private readonly ILogger<DiskPersistingSigningRequestTracker> _logger;
+    private readonly SigningServerConfiguration _configuration;
+    private CancellationTokenSource _backgroundWorkerCancellation = new();
+    private Task? _backgroundWorker;
+
+    public DiskPersistingSigningRequestTracker(ILogger<DiskPersistingSigningRequestTracker> logger,
+        SigningServerConfiguration configuration)
+    {
+        _logger = logger;
+        _configuration = configuration;
+        LoadCurrentDay();
+        StartBackgroundFlushWorker();
+    }
+
+    private void StartBackgroundFlushWorker()
+    {
+        _backgroundWorkerCancellation = new CancellationTokenSource();
+        _backgroundWorker = Task.Run(() => BackgroundFlushLoop(_backgroundWorkerCancellation.Token));
+    }
+
+    private async Task BackgroundFlushLoop(CancellationToken token)
+    {
+        try
+        {
+            while (!token.IsCancellationRequested)
+            {
+                await Task.Delay(_configuration.AuditFlushInterval, token);
+                await FlushToDisk(await GetCurrentDay(true, token), token);
+            }
+        }
+        finally
+        {
+            using var shutdown = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+            await FlushToDisk(await GetCurrentDay(true, shutdown.Token), shutdown.Token);
+        }
+    }
+
+    private async Task FlushToDisk(SigningRequestTrackingLogFile file, CancellationToken token)
+    {
+        var fileName = GetFileName(file.Date);
+        try
+        {
+            var text = JsonSerializer.Serialize(file, JsonOptions);
+            await File.WriteAllTextAsync(fileName, text, token);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Failed to flush signing request tracking log file {FileName}", fileName);
+        }
+    }
+
+    private async Task<SigningRequestTrackingLogFile> GetCurrentDay(bool updateToCurrentDayIfNeeded,
+        CancellationToken token)
+    {
+        await _currentDayLock.WaitAsync(token);
+        try
+        {
+            if (_currentDay == null)
+            {
+                _currentDay = new SigningRequestTrackingLogFile { Date = DateTime.UtcNow.Date };
+            }
+            else if (updateToCurrentDayIfNeeded && DateTime.UtcNow.Date > _currentDay.Date)
+            {
+                await FlushToDisk(_currentDay, token);
+                _currentDay = new SigningRequestTrackingLogFile { Date = DateTime.UtcNow };
+            }
+
+            return _currentDay;
+        }
+        finally
+        {
+            _currentDayLock.Release();
+        }
+    }
+
+    private void LoadCurrentDay()
+    {
+        var date = DateTime.UtcNow.Date;
+        var fileName = GetFileName(date);
+        if (!File.Exists(fileName))
+        {
+            _logger.LogInformation("No signing request tracking log file found for {Date}, starting fresh.", date);
+            return;
+        }
+
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(fileName)!);
+            _currentDay =
+                JsonSerializer.Deserialize<SigningRequestTrackingLogFile>(File.ReadAllText(fileName), JsonOptions)!;
+            _logger.LogInformation("Loaded signing request tracking log file {FileName}", fileName);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Failed to load signing request tracking log file {FileName}", fileName);
+        }
+    }
+
+    public void Dispose()
+    {
+        StopBackgroundFlushWorker();
+    }
+
+    private void StopBackgroundFlushWorker()
+    {
+        _backgroundWorkerCancellation.Cancel();
+        _backgroundWorker?.Wait();
+    }
+
+    private string GetFileName(DateTime date)
+    {
+        return Path.Combine("audit", $"signing-requests-{date:yyyy-MM-dd}.json");
+    }
+
+    public async Task TrackRequestAsync(
+        string userInfo,
+        SignFileResponseStatus status, int numberOfSignatures
+    )
+    {
+        var currentDay = await GetCurrentDay(true, CancellationToken.None);
+        currentDay.TrackRequest(userInfo, status, numberOfSignatures);
+    }
+}

--- a/SigningServer.Server/PooledCertificateProvider.cs
+++ b/SigningServer.Server/PooledCertificateProvider.cs
@@ -87,7 +87,7 @@ public class PooledCertificateProvider : ICertificateProvider
         }
     }
 
-    public Lazy<ValueTask<CertificateConfiguration>>? Get(string? username, string? password)
+    public ICertificateAccessor? Get(string? username, string? password)
     {
         CertificateConfiguration? baseConfiguration;
         if (string.IsNullOrWhiteSpace(username))
@@ -110,7 +110,13 @@ public class PooledCertificateProvider : ICertificateProvider
             _ => new CertificatePool(_logger, baseConfiguration, _certConfigLogger, _hardwareCertificateUnlocker)
         );
 
-        return new Lazy<ValueTask<CertificateConfiguration>>(() => GetWorkingFromPoolAsync(pool));
+        var certificateName = !string.IsNullOrEmpty(baseConfiguration.CertificateName)
+            ? baseConfiguration.CertificateName
+            : baseConfiguration.Username ?? "default";
+        return new PooledCertificateAccessor(
+            certificateName,
+            new Lazy<ValueTask<CertificateConfiguration>>(() => GetWorkingFromPoolAsync(pool))
+        );
     }
 
     private static readonly byte[] SignTestSha2Hash = ((Func<byte[]>)(() =>
@@ -180,9 +186,9 @@ public class PooledCertificateProvider : ICertificateProvider
         return cert;
     }
 
-    public async ValueTask ReturnAsync(string? username, Lazy<ValueTask<CertificateConfiguration>> certificateConfiguration)
+    public async ValueTask ReturnAsync(string? username, ICertificateAccessor certificateConfiguration)
     {
-        if (certificateConfiguration is not { IsValueCreated: true })
+        if (certificateConfiguration is not PooledCertificateAccessor { Configuration.IsValueCreated: true } accessor)
         {
             return;
         }
@@ -192,17 +198,17 @@ public class PooledCertificateProvider : ICertificateProvider
             username = string.Empty;
         }
 
-        _certificatePools[username].Return(await certificateConfiguration.Value);
+        _certificatePools[username].Return(await accessor.Configuration.Value);
     }
 
-    public async ValueTask DestroyAsync(Lazy<ValueTask<CertificateConfiguration>>? certificateConfiguration)
+    public async ValueTask DestroyAsync(ICertificateAccessor? certificateConfiguration)
     {
-        if (certificateConfiguration is not { IsValueCreated: true })
+        if (certificateConfiguration is not PooledCertificateAccessor { Configuration.IsValueCreated: true } accessor)
         {
             return;
         }
 
-        Destroy(await certificateConfiguration.Value);
+        Destroy(await accessor.Configuration.Value);
     }
 
     private void Destroy(CertificateConfiguration certificateConfiguration)
@@ -223,6 +229,25 @@ public class PooledCertificateProvider : ICertificateProvider
         catch (Exception e)
         {
             _logger.LogInformation(e, "Error during disposing of PrivateKey");
+        }
+    }
+
+    private class PooledCertificateAccessor : ICertificateAccessor
+    {
+        public string CertificateName { get; }
+        public Lazy<ValueTask<CertificateConfiguration>> Configuration { get; }
+
+        public PooledCertificateAccessor(
+            string certificateName,
+            Lazy<ValueTask<CertificateConfiguration>> configuration)
+        {
+            CertificateName = certificateName;
+            Configuration = configuration;
+        }
+
+        public ValueTask<CertificateConfiguration> UseCertificate()
+        {
+            return Configuration.Value;
         }
     }
 }

--- a/SigningServer.Server/Startup.cs
+++ b/SigningServer.Server/Startup.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using SigningServer.Android.Collections;
@@ -36,6 +37,7 @@ public class Startup
         services.AddTransient<IHostedService>(sp => sp.GetRequiredService<HardwareCertificateUnlocker>());
         services.AddSingleton<ISigningToolProvider, DefaultSigningToolProvider>();
         services.AddSingleton<IHashSigningTool, ManagedHashSigningTool>();
+        services.TryAddSingleton<ISigningRequestTracker, DiskPersistingSigningRequestTracker>();
         services.AddSingleton<ICertificateProvider, PooledCertificateProvider>();
         services.Configure<FormOptions>(x =>
         {

--- a/SigningServer.Signing/Configuration/CertificateConfiguration.cs
+++ b/SigningServer.Signing/Configuration/CertificateConfiguration.cs
@@ -13,6 +13,11 @@ namespace SigningServer.Signing.Configuration;
 public class CertificateConfiguration
 {
     /// <summary>
+    /// A name of the certificate for identification (in logs and configuration).
+    /// </summary>
+    public string CertificateName { get; set; } = "";
+    
+    /// <summary>
     /// The plain text username to use this certificate
     /// </summary>
     public string? Username { get; set; }

--- a/SigningServer.Signing/Configuration/SigningServerApiConfiguration.cs
+++ b/SigningServer.Signing/Configuration/SigningServerApiConfiguration.cs
@@ -251,29 +251,7 @@ public class SigningServerApiConfiguration
 
         public override byte[] Decrypt(byte[] data, RSAEncryptionPadding padding)
         {
-            try
-            {
-                var response = _client.PostAsJsonAsync("signing/decryptrsa", new DecryptRsaRequestDto(
-                    _configuration.Username,
-                    _configuration.Password,
-                    Convert.ToBase64String(data),
-                    padding.OaepHashAlgorithm.Name!,
-                    padding.Mode)).GetAwaiter().GetResult();
-
-                var responseDto = response.Content.ReadFromJsonAsync<DecryptRsaResponseDto>()
-                    .GetAwaiter().GetResult();
-
-                if (!string.IsNullOrEmpty(responseDto?.ErrorMessage))
-                {
-                    throw new CryptographicException(responseDto.ErrorMessage);
-                }
-
-                return Convert.FromBase64String(responseDto!.Data!);
-            }
-            catch (Exception e)
-            {
-                throw new CryptographicException("Error calling SigningServer", e);
-            }
+            throw new NotSupportedException();
         }
 
         public override byte[] SignHash(byte[] hash, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding)

--- a/SigningServer.StandaloneClient/Program.cs
+++ b/SigningServer.StandaloneClient/Program.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.EnvironmentVariables;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -32,6 +33,11 @@ internal static class Program
             })
             .ConfigureAppConfiguration(config =>
             {
+                foreach (var envSources in config.Sources.OfType<EnvironmentVariablesConfigurationSource>().ToArray())
+                {
+                    config.Sources.Remove(envSources);
+                }
+                config.AddEnvironmentVariables("SIGNINGSERVER_CLIENT_");
                 config.AddJsonFile("config.json", optional: true);
             })
             .ConfigureServices(services =>

--- a/SigningServer.StandaloneClient/StandaloneSigningClientConfiguration.cs
+++ b/SigningServer.StandaloneClient/StandaloneSigningClientConfiguration.cs
@@ -21,6 +21,8 @@ public class StandaloneSigningClientConfiguration : SigningClientConfigurationBa
 {
     public ServerType ServerType { get; set; }
 
+    public override string CredentialInfo => "local";
+
     /// <summary>
     /// A RFC-3161 compliant timestamping server which should be used.
     /// </summary>

--- a/SigningServer.Tests/RequestTrackingTest.cs
+++ b/SigningServer.Tests/RequestTrackingTest.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -40,9 +41,15 @@ public class RequestTrackingTest : UnitTestBase
                                 },
                                 new CertificateConfiguration
                                 {
-                                    CertificateName = "user1",
-                                    Username = "user1",
-                                    Password = "pass1",
+                                    CertificateName = "Cert2",
+                                    Credentials = new[]
+                                    {
+                                        new CertificateAccessCredentials
+                                        {
+                                            Username = "user1",
+                                            Password = "pass1",   
+                                        }
+                                    },
                                     Certificate = AssemblyEvents.Certificate.Value.GetAwaiter().GetResult(),
                                     PrivateKey = AssemblyEvents.PrivateKey.Value.GetAwaiter().GetResult()
                                 }
@@ -69,15 +76,55 @@ public class RequestTrackingTest : UnitTestBase
         using (var client = new SigningClient(Application!.CreateClient(),
                    Application.Services.GetRequiredService<ILogger<SigningClient>>(),
                    Path.Combine(ExecutionDirectory, "RequestTrackingTest", "unsigned", "Unsigned.dll"),
-                       Path.Combine(ExecutionDirectory, "RequestTrackingTest", "signed", "Signed.dll")))
+                   Path.Combine(ExecutionDirectory, "RequestTrackingTest", "signed", "Signed.dll")))
         {
             await client.InitializeAsync();
             await client.SignFilesAsync();    
         }
 
-        tracker.CurrentDay.Entries.Should().ContainKey("unknown-TestDefault");
-        tracker.CurrentDay.Entries["unknown-TestDefault"].TotalNumberOfRequests.Should().Be(2);
-        tracker.CurrentDay.Entries["unknown-TestDefault"].TotalNumberOfSignaturesCreated.Should().Be(1);
-        tracker.CurrentDay.Entries["unknown-TestDefault"].TotalNumberOfSignaturesSkipped.Should().Be(1);
+        tracker.CurrentDay.Entries.Should().ContainKey("Anonymous-TestDefault");
+        tracker.CurrentDay.Entries["Anonymous-TestDefault"].TotalNumberOfRequests.Should().Be(2);
+        tracker.CurrentDay.Entries["Anonymous-TestDefault"].TotalNumberOfSignaturesCreated.Should().Be(1);
+        tracker.CurrentDay.Entries["Anonymous-TestDefault"].TotalNumberOfSignaturesSkipped.Should().Be(1);
+        
+        using (var client = new SigningClient(Application!.CreateClient(),
+                   Application.Services.GetRequiredService<ILogger<SigningClient>>(),
+                   Path.Combine(ExecutionDirectory, "RequestTrackingTest", "unsigned", "Unsigned.exe"),
+                   Path.Combine(ExecutionDirectory, "RequestTrackingTest", "signed", "Signed.exe")))
+        {
+            client.Configuration.Username = "user1";
+            client.Configuration.Password = "pass1";
+            await client.InitializeAsync();
+            await client.SignFilesAsync();    
+        }
+
+        tracker.CurrentDay.Entries.Should().ContainKey("user1-Cert2");
+        tracker.CurrentDay.Entries["user1-Cert2"].TotalNumberOfRequests.Should().Be(2);
+        tracker.CurrentDay.Entries["user1-Cert2"].TotalNumberOfSignaturesCreated.Should().Be(1);
+        tracker.CurrentDay.Entries["user1-Cert2"].TotalNumberOfSignaturesSkipped.Should().Be(1);
+
+        
+        using (var client = new SigningClient(Application!.CreateClient(),
+                   Application.Services.GetRequiredService<ILogger<SigningClient>>(),
+                   Path.Combine(ExecutionDirectory, "RequestTrackingTest", "unsigned", "Unsigned.exe")))
+        {
+            client.Configuration.Username = "invalid";
+            client.Configuration.Password = "invalid";
+            await client.InitializeAsync();
+            try
+            {
+                await client.SignFilesAsync();
+                Assert.Fail("Expected error because of invalid credentials");
+            }
+            catch (UnauthorizedAccessException)
+            {
+                // expected
+            }
+        }
+
+        tracker.CurrentDay.Entries.Should().ContainKey("invalid");
+        tracker.CurrentDay.Entries["invalid"].TotalNumberOfRequests.Should().Be(1);
+        tracker.CurrentDay.Entries["invalid"].TotalNumberOfSignaturesCreated.Should().Be(0);
+        tracker.CurrentDay.Entries["invalid"].TotalNumberOfSignaturesSkipped.Should().Be(1);
     }
 }

--- a/SigningServer.Tests/RequestTrackingTest.cs
+++ b/SigningServer.Tests/RequestTrackingTest.cs
@@ -1,0 +1,83 @@
+﻿using System.IO;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+using SigningServer.Client;
+using SigningServer.Server;
+using SigningServer.Server.Configuration;
+using SigningServer.Signing.Configuration;
+
+namespace SigningServer.Test;
+
+public class RequestTrackingTest : UnitTestBase
+{
+    protected WebApplicationFactory<Program>? Application { get; private set; }
+
+    [OneTimeSetUp]
+    public void Setup()
+    {
+        Application = new WebApplicationFactory<Program>()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureServices(services =>
+                {
+                    services.Replace(ServiceDescriptor.Singleton(
+                        new SigningServerConfiguration
+                        {
+                            TimestampServer = TimestampServer,
+                            Sha1TimestampServer = Sha1TimestampServer,
+                            Certificates = new[]
+                            {
+                                new CertificateConfiguration
+                                {
+                                    CertificateName = "TestDefault",
+                                    Certificate = AssemblyEvents.Certificate.Value.GetAwaiter().GetResult(),
+                                    PrivateKey = AssemblyEvents.PrivateKey.Value.GetAwaiter().GetResult()
+                                },
+                                new CertificateConfiguration
+                                {
+                                    CertificateName = "user1",
+                                    Username = "user1",
+                                    Password = "pass1",
+                                    Certificate = AssemblyEvents.Certificate.Value.GetAwaiter().GetResult(),
+                                    PrivateKey = AssemblyEvents.PrivateKey.Value.GetAwaiter().GetResult()
+                                }
+                            },
+                            WorkingDirectory = "WorkingDirectory"
+                        }));
+                    services.Replace(ServiceDescriptor.Singleton<ISigningRequestTracker>(
+                        new TestingSigningRequestTracker()));
+                });
+            });
+    }
+
+    [OneTimeTearDown]
+    public void Shutdown()
+    {
+        Application?.Dispose();
+    }
+    
+    [Test]
+    [DeploymentItem("TestFiles", "RequestTrackingTest")]
+    public async Task EnsureTrackingWorks()
+    {
+        var tracker = (TestingSigningRequestTracker)Application!.Services.GetRequiredService<ISigningRequestTracker>();
+        using (var client = new SigningClient(Application!.CreateClient(),
+                   Application.Services.GetRequiredService<ILogger<SigningClient>>(),
+                   Path.Combine(ExecutionDirectory, "RequestTrackingTest", "unsigned", "Unsigned.dll"),
+                       Path.Combine(ExecutionDirectory, "RequestTrackingTest", "signed", "Signed.dll")))
+        {
+            await client.InitializeAsync();
+            await client.SignFilesAsync();    
+        }
+
+        tracker.CurrentDay.Entries.Should().ContainKey("unknown-TestDefault");
+        tracker.CurrentDay.Entries["unknown-TestDefault"].TotalNumberOfRequests.Should().Be(2);
+        tracker.CurrentDay.Entries["unknown-TestDefault"].TotalNumberOfSignaturesCreated.Should().Be(1);
+        tracker.CurrentDay.Entries["unknown-TestDefault"].TotalNumberOfSignaturesSkipped.Should().Be(1);
+    }
+}

--- a/SigningServer.Tests/SigningControllerSigningTest.cs
+++ b/SigningServer.Tests/SigningControllerSigningTest.cs
@@ -23,7 +23,6 @@ using SignFileResponse = SigningServer.Core.SignFileResponse;
 
 namespace SigningServer.Test;
 
-
 public class SigningControllerSigningTest : UnitTestBase
 {
     private SigningServerConfiguration _configuration = null!;
@@ -68,10 +67,7 @@ public class SigningControllerSigningTest : UnitTestBase
     {
         var server = new SigningController(AssemblyEvents.LoggerProvider.CreateLogger<SigningController>(),
             _emptySigningToolProvider, null!, _configuration, new NonPooledCertificateProvider(_configuration),
-            new TestingSigningRequestTracker())
-        {
-            ControllerContext = CreateEmptyControllerContext()
-        };
+            new TestingSigningRequestTracker()) { ControllerContext = CreateEmptyControllerContext() };
 
         var request = new SignFileRequestDto
         {
@@ -94,8 +90,14 @@ public class SigningControllerSigningTest : UnitTestBase
             {
                 new CertificateConfiguration
                 {
-                    Username = "SignUser",
-                    Password = "SignPass",
+                    Credentials =
+                        new[]
+                        {
+                            new CertificateAccessCredentials
+                            {
+                                Username = "SignUser", Password = "SignPass",
+                            }
+                        },
                     Certificate = await AssemblyEvents.Certificate.Value,
                     PrivateKey = await AssemblyEvents.PrivateKey.Value
                 }
@@ -105,10 +107,7 @@ public class SigningControllerSigningTest : UnitTestBase
 
         var server = new SigningController(AssemblyEvents.LoggerProvider.CreateLogger<SigningController>(),
             _emptySigningToolProvider, null!, configuration, new NonPooledCertificateProvider(configuration),
-            new TestingSigningRequestTracker())
-        {
-            ControllerContext = CreateEmptyControllerContext()
-        };
+            new TestingSigningRequestTracker()) { ControllerContext = CreateEmptyControllerContext() };
 
         var testData =
             new MemoryStream(
@@ -134,10 +133,7 @@ public class SigningControllerSigningTest : UnitTestBase
     {
         var server = new SigningController(AssemblyEvents.LoggerProvider.CreateLogger<SigningController>(),
             _emptySigningToolProvider, null!, _configuration, new NonPooledCertificateProvider(_configuration),
-            new TestingSigningRequestTracker())
-        {
-            ControllerContext = CreateEmptyControllerContext()
-        };
+            new TestingSigningRequestTracker()) { ControllerContext = CreateEmptyControllerContext() };
 
         var testData =
             new MemoryStream(
@@ -156,10 +152,7 @@ public class SigningControllerSigningTest : UnitTestBase
     {
         var server = new SigningController(AssemblyEvents.LoggerProvider.CreateLogger<SigningController>(),
             _simulateSigningToolProvider, null!, _configuration, new NonPooledCertificateProvider(_configuration),
-            new TestingSigningRequestTracker())
-        {
-            ControllerContext = CreateEmptyControllerContext()
-        };
+            new TestingSigningRequestTracker()) { ControllerContext = CreateEmptyControllerContext() };
 
         var testData =
             new MemoryStream(

--- a/SigningServer.Tests/SigningControllerSigningTest.cs
+++ b/SigningServer.Tests/SigningControllerSigningTest.cs
@@ -67,7 +67,8 @@ public class SigningControllerSigningTest : UnitTestBase
     public async Task SignFile_EmptyFile_Fails()
     {
         var server = new SigningController(AssemblyEvents.LoggerProvider.CreateLogger<SigningController>(),
-            _emptySigningToolProvider, null!, _configuration, new NonPooledCertificateProvider(_configuration))
+            _emptySigningToolProvider, null!, _configuration, new NonPooledCertificateProvider(_configuration),
+            new TestingSigningRequestTracker())
         {
             ControllerContext = CreateEmptyControllerContext()
         };
@@ -103,7 +104,8 @@ public class SigningControllerSigningTest : UnitTestBase
         };
 
         var server = new SigningController(AssemblyEvents.LoggerProvider.CreateLogger<SigningController>(),
-            _emptySigningToolProvider, null!, configuration, new NonPooledCertificateProvider(configuration))
+            _emptySigningToolProvider, null!, configuration, new NonPooledCertificateProvider(configuration),
+            new TestingSigningRequestTracker())
         {
             ControllerContext = CreateEmptyControllerContext()
         };
@@ -131,7 +133,8 @@ public class SigningControllerSigningTest : UnitTestBase
     public async Task SignFile_UnsupportedFormat_Fails()
     {
         var server = new SigningController(AssemblyEvents.LoggerProvider.CreateLogger<SigningController>(),
-            _emptySigningToolProvider, null!, _configuration, new NonPooledCertificateProvider(_configuration))
+            _emptySigningToolProvider, null!, _configuration, new NonPooledCertificateProvider(_configuration),
+            new TestingSigningRequestTracker())
         {
             ControllerContext = CreateEmptyControllerContext()
         };
@@ -152,7 +155,8 @@ public class SigningControllerSigningTest : UnitTestBase
     public async Task SignFile_UploadsFileToWorkingDirectory()
     {
         var server = new SigningController(AssemblyEvents.LoggerProvider.CreateLogger<SigningController>(),
-            _simulateSigningToolProvider, null!, _configuration, new NonPooledCertificateProvider(_configuration))
+            _simulateSigningToolProvider, null!, _configuration, new NonPooledCertificateProvider(_configuration),
+            new TestingSigningRequestTracker())
         {
             ControllerContext = CreateEmptyControllerContext()
         };

--- a/SigningServer.Tests/SigningServerIntegrationTestBase.cs
+++ b/SigningServer.Tests/SigningServerIntegrationTestBase.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using NUnit.Framework;
 using SigningServer.ClientCore;
 using SigningServer.Core;
+using SigningServer.Server;
 using SigningServer.Server.Configuration;
 using SigningServer.Signing;
 using SigningServer.Signing.Configuration;
@@ -49,6 +50,8 @@ public abstract class SigningServerIntegrationTestBase : UnitTestBase
                             },
                             WorkingDirectory = "WorkingDirectory"
                         }));
+                    services.Replace(ServiceDescriptor.Singleton<ISigningRequestTracker>(
+                        new TestingSigningRequestTracker()));
                 });
             });
     }

--- a/SigningServer.Tests/TestingSigningRequestTracker.cs
+++ b/SigningServer.Tests/TestingSigningRequestTracker.cs
@@ -1,0 +1,16 @@
+﻿using System.Threading.Tasks;
+using SigningServer.Core;
+using SigningServer.Server;
+
+namespace SigningServer.Test;
+
+public class TestingSigningRequestTracker : ISigningRequestTracker
+{
+    public SigningRequestTrackingLogFile CurrentDay { get; } = new();
+
+    public Task TrackRequestAsync(string userInfo, SignFileResponseStatus status, int numberOfSignatures)
+    {
+        CurrentDay.TrackRequest(userInfo, status, numberOfSignatures);
+        return Task.CompletedTask;
+    }
+}

--- a/SigningServer.Tests/nlog.config
+++ b/SigningServer.Tests/nlog.config
@@ -6,8 +6,8 @@
       internalLogLevel="Off" internalLogFile="c:\temp\nlog-internal.log" >
 
   <targets>
-    <target xsi:type="ColoredConsole" name="console" layout="${longdate} ${level} ${callsite:cleanNamesOfAsyncContinuations=true:cleanNamesOfAnonymousDelegates=true} - ${message} ${exception:format=ToString}" detectConsoleAvailable="false" />
-    <target xsi:type="Debugger" name="debugger" layout="${longdate} ${level} ${callsite:cleanNamesOfAsyncContinuations=true:cleanNamesOfAnonymousDelegates=true} - ${message} ${exception:format=ToString}"/>
+    <target xsi:type="ColoredConsole" name="console" layout="${longdate} ${level} ${callsite:cleanNamesOfAsyncContinuations=true:cleanNamesOfAnonymousDelegates=true} ${aspnet-TraceIdentifier} - ${message} ${exception:format=ToString}" detectConsoleAvailable="false" />
+    <target xsi:type="Debugger" name="debugger" layout="${longdate} ${level} ${callsite:cleanNamesOfAsyncContinuations=true:cleanNamesOfAnonymousDelegates=true} ${aspnet-TraceIdentifier} - ${message} ${exception:format=ToString}"/>
   </targets>
 
   <rules>

--- a/SigningServer.sln
+++ b/SigningServer.sln
@@ -12,6 +12,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "CommonFiles", "CommonFiles"
 		Directory.Build.props = Directory.Build.props
 		README.md = README.md
 		LICENSE = LICENSE
+		BREAKING_CHANGES.md = BREAKING_CHANGES.md
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SigningServer.Core", "SigningServer.Core\SigningServer.Core.csproj", "{EC706B59-9540-45A3-A6E3-29634855DA74}"


### PR DESCRIPTION
This PR consists of two parts aiming for the same goal: Better access control and auditing capabilities. 

1. Instead of one user/pass which identifies the certificate, users can now share certificates. You can define multiple credential pairs for different teams/departments sharing the same certificate.
2. The usage of the service is now tracked. While we do not store the details of each and every requests semantically, the service stores who used which certificate how often. This allows taking decisions based on the usage of the certificates. 

As this is a breaking change, version was bumped to 3.0