### PR TITLE
Make configuration file lookup independent of current directory

### DIFF
--- a/SigningServer.Client/Program.cs
+++ b/SigningServer.Client/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
@@ -37,7 +38,7 @@ internal static class Program
                     config.Sources.Remove(envSources);
                 }
                 config.AddEnvironmentVariables("SIGNINGSERVER_CLIENT_");
-                config.AddJsonFile("config.json", optional: true);
+                config.AddJsonFile(Path.Combine(AppContext.BaseDirectory, "config.json"), optional: true);
             })
             .ConfigureServices(services =>
             {

--- a/SigningServer.StandaloneClient/Program.cs
+++ b/SigningServer.StandaloneClient/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
@@ -38,7 +39,7 @@ internal static class Program
                     config.Sources.Remove(envSources);
                 }
                 config.AddEnvironmentVariables("SIGNINGSERVER_CLIENT_");
-                config.AddJsonFile("config.json", optional: true);
+                config.AddJsonFile(Path.Combine(AppContext.BaseDirectory, "config.json"), optional: true);
             })
             .ConfigureServices(services =>
             {


### PR DESCRIPTION
Fixes e.g. missing output of client when current directory is not application path.

This is especially annoying when invoking signing server client from Nuke.
